### PR TITLE
Metrics bug fixes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -309,15 +309,6 @@ function createCpuListener() {
   });
 }
 
-function createHeapListener() {
-  monitor.on('heap', function() {
-    var mem = process.memoryUsage();
-    heapMetrics.total += mem.heapTotal;
-    heapMetrics.used += mem.heapUsed;
-    heapMetrics.count++;
-  });
-}
-
 function createGcListener() {
   monitor.on('gc', function(res) {
     gcMetrics.used += res.used;
@@ -513,7 +504,6 @@ function initialise() {
   // Set up listeners for all the metrics here
   createEventLoopListener();
   createCpuListener();
-  createHeapListener();
   createGcListener();
   createMessageListener();
   createHttpListener();

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -71,11 +71,6 @@ var probeList = [
   'express',
 ];
 var probeMetrics = {};
-var heapMetrics = {
-  total: 0,
-  used: 0,
-  count: 0,
-};
 var gcMetrics = {
   used: 0,
   count: 0,
@@ -315,9 +310,10 @@ function createCpuListener() {
 }
 
 function createHeapListener() {
-  monitor.on('heap', function(res) {
-    heapMetrics.total += res.total;
-    heapMetrics.used += res.used;
+  monitor.on('heap', function() {
+    var mem = process.memoryUsage();
+    heapMetrics.total += mem.heapTotal;
+    heapMetrics.used += mem.heapUsed;
     heapMetrics.count++;
   });
 }
@@ -450,12 +446,12 @@ function getProbeData(probeName) {
 }
 
 function getHeapData() {
-  var jsonToReturn = heapMetrics;
-
-  // Reset JSON
-  heapMetrics = {};
-
-  return jsonToReturn;
+  var mem = process.memoryUsage();
+  return {
+    total: mem.heapTotal,
+    used: mem.heapUsed,
+    count: 1
+  };
 }
 
 function getGcHeapData() {


### PR DESCRIPTION
These commits change the metrics reporter to grab heap usage once per loop, rather than accumulating it possibly multiple times per loop. They also remove the `createHeapListener` function, which listens for a nonexistent event.
