### PR TITLE
Fix express probe behavior

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -352,7 +352,7 @@ function createMessageListener() {
 function createProbeListener(probeName) {
   monitor.on(probeName, function(res) {
     var duration = 0;
-    if (probeName === 'express') {
+    if (res.hasOwnProperty('response') && res.response.hasOwnProperty('duration')) {
       duration = res.response.duration;
     } else {
       duration = res.duration;


### PR DESCRIPTION
`res.response` is not guaranteed to exist. Additionally, the official appmetrics readme states that the `express` probe will yield a top-level `duration` property: https://github.com/RuntimeTools/appmetrics#event-express
