### PR TITLE
Prevent master process crashes when cpuData contains null values

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -117,9 +117,9 @@ function use(callback) {
 
     debug('cpuData: %j', cpuData);
     // FIXME cpuData is {'system':null,'user':null,'total':null}
-    if (typeof cpuData.total !== 'undefined' &&
-        typeof cpuData.system !== 'undefined' &&
-        typeof cpuData.user !== 'undefined') {
+    if (typeof cpuData.total !== 'undefined' && cpuData.total !== null
+        typeof cpuData.system !== 'undefined' && cpuData.system !== null
+        typeof cpuData.user !== 'undefined' && cpuData.user !== null) {
       console.assert(cpuData.system >= 0);
       console.assert(cpuData.total >= 0);
       console.assert(cpuData.user >= 0);


### PR DESCRIPTION
@shelbys RC and I were not able to solve the mystery of the `memory` monitoring. We decided to simply add a condition to avoid null values, thus preventing the crash of the master process.