### PR TITLE
Prevent master process crashes if cpuData is invalid

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -117,15 +117,16 @@ function use(callback) {
 
     debug('cpuData: %j', cpuData);
     // FIXME cpuData is {'system':null,'user':null,'total':null}
-    if (typeof cpuData.total !== 'undefined' && cpuData.total !== null &&
-        typeof cpuData.system !== 'undefined' && cpuData.system !== null &&
-        typeof cpuData.user !== 'undefined' && cpuData.user !== null) {
-      console.assert(cpuData.system >= 0);
-      console.assert(cpuData.total >= 0);
-      console.assert(cpuData.user >= 0);
-      callback('cpu.system', cpuData.system);
-      callback('cpu.total', cpuData.total);
-      callback('cpu.user', cpuData.user);
+    if (typeof cpuData.total === 'number' &&
+        typeof cpuData.system === 'number' &&
+        typeof cpuData.user === 'number') {
+      if (cpuData.system >= 0 && cpuData.total >= 0 && cpuData.user >= 0) {
+        callback('cpu.system', cpuData.system);
+        callback('cpu.total', cpuData.total);
+        callback('cpu.user', cpuData.user);
+      } else {
+        console.log('cpuData is invalid: ', cpuData);
+      }
     }
 
     callback('http.connection.count', httpData.count);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -353,7 +353,8 @@ function createMessageListener() {
 function createProbeListener(probeName) {
   monitor.on(probeName, function(res) {
     var duration = 0;
-    if (res.hasOwnProperty('response') && res.response.hasOwnProperty('duration')) {
+    if (res.hasOwnProperty('response') &&
+        res.response.hasOwnProperty('duration')) {
       duration = res.response.duration;
     } else {
       duration = res.duration;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "supervisor and monitor for node.js applications",
   "author": "Sam Roberts <sam@strongloop.com>",
   "license": "Artistic-2.0",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "index.js",
   "keywords": [
     "agent",


### PR DESCRIPTION
From the Node.js documentation:

> Note: the console.assert() method is implemented differently in Node.js than the console.assert() method available in browsers.

> Specifically, in browsers, calling console.assert() with a falsy assertion will cause the message to be printed to the console without interrupting execution of subsequent code. In Node.js, however, a falsy assertion will cause an AssertionError to be thrown.